### PR TITLE
add: ortho switcher

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -13,6 +13,16 @@ const config: Config = {
   organizationName: 'medzuslovjansky',
   projectName: 'standard',
   onBrokenLinks: 'throw',
+  // Apply the reader's saved alphabet choice before first paint so
+  // etymological text does not flash in the default alphabet.
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML:
+        "(function(){try{var a=localStorage.getItem('isv-alphabet');if(a){document.documentElement.setAttribute('data-isv-alphabet',a);}}catch(e){}})();",
+    },
+  ],
   markdown: {
     hooks: {
       onBrokenMarkdownLinks: 'warn',
@@ -57,6 +67,10 @@ const config: Config = {
         src: 'img/logo.svg',
       },
       items: [
+        {
+          type: 'custom-alphabetSwitcher',
+          position: 'right',
+        },
         {
           href: 'https://github.com/medzuslovjansky/standard',
           label: 'GitHub',

--- a/src/components/AlphabetSwitcher/index.tsx
+++ b/src/components/AlphabetSwitcher/index.tsx
@@ -1,0 +1,61 @@
+import React, {useEffect, useState} from 'react';
+import styles from './styles.module.css';
+
+/**
+ * Navbar dropdown that selects which alphabet `:etym[…]` text is displayed in.
+ *
+ * The choice is stored on `<html data-isv-alphabet="…">` (read by CSS) and
+ * persisted to localStorage. An inline <head> script (see docusaurus.config.ts)
+ * applies the stored value before first paint to avoid a flash of the default.
+ */
+
+const STORAGE_KEY = 'isv-alphabet';
+
+const OPTIONS: ReadonlyArray<[value: string, label: string]> = [
+  ['etym', 'Etymological'],
+  ['latn', 'Latin'],
+  ['cyrl', 'Cyrillic'],
+];
+
+export default function AlphabetSwitcher(): React.ReactElement {
+  // Render the default on the server; sync from storage after mount.
+  const [value, setValue] = useState('etym');
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        setValue(stored);
+      }
+    } catch {
+      /* localStorage unavailable — keep the default */
+    }
+  }, []);
+
+  const onChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const next = event.target.value;
+    setValue(next);
+    document.documentElement.setAttribute('data-isv-alphabet', next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* ignore persistence failures */
+    }
+  };
+
+  return (
+    <select
+      className={styles.switcher}
+      value={value}
+      onChange={onChange}
+      aria-label="Etymological alphabet display"
+      title="Choose the alphabet for etymological text"
+    >
+      {OPTIONS.map(([optionValue, label]) => (
+        <option key={optionValue} value={optionValue}>
+          {label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/AlphabetSwitcher/styles.module.css
+++ b/src/components/AlphabetSwitcher/styles.module.css
@@ -1,0 +1,15 @@
+.switcher {
+  margin: 0 0.5rem;
+  padding: 0.25rem 1.5rem 0.25rem 0.5rem;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--ifm-navbar-link-color);
+  background-color: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  cursor: pointer;
+}
+
+.switcher:hover {
+  border-color: var(--ifm-color-emphasis-500);
+}

--- a/src/custom.css
+++ b/src/custom.css
@@ -4,6 +4,31 @@
  * work well for content-centric websites.
  */
 
+/**
+ * Etymological alphabet switching for :etym[…] directives.
+ *
+ * The remark plugin renders all three alphabets as sibling spans. Exactly one
+ * is shown, selected by the `data-isv-alphabet` attribute on <html> (set by the
+ * navbar AlphabetSwitcher). With no attribute, the etymological form is shown.
+ */
+.etym-latn,
+.etym-cyrl {
+  display: none;
+}
+
+html[data-isv-alphabet='latn'] .etym-etym,
+html[data-isv-alphabet='cyrl'] .etym-etym {
+  display: none;
+}
+
+html[data-isv-alphabet='latn'] .etym-latn {
+  display: inline;
+}
+
+html[data-isv-alphabet='cyrl'] .etym-cyrl {
+  display: inline;
+}
+
 /* You can override the default Infima variables here. */
 :root {
   --ifm-color-primary: #1a56b0;

--- a/src/isv-etym.js
+++ b/src/isv-etym.js
@@ -1,0 +1,124 @@
+/**
+ * Converters for the Interslavic etymological ("Scientific" / MS Plus) alphabet.
+ *
+ * Input is always assumed to be written in the etymological Latin alphabet.
+ * We derive two other renderings:
+ *   - standard Latin      (etymological diacritics folded away)
+ *   - standard Cyrillic    (via the normative Latin→Cyrillic transliteration)
+ *
+ * The mappings are taken from docs/04-orthography/03-etymological.md and
+ * docs/04-orthography/04-transliteration.md. This is intentionally a
+ * character-level converter — "good enough", not a morphological engine.
+ */
+
+// Etymological letter → standard Latin.
+// Keys are lowercase; casing is restored automatically. Note the two soft
+// letters written with a combining acute (t + U+0301, d + U+0301) as well as
+// their precomposed caron variants.
+const ETYM_TO_LATIN = [
+  // vowels
+  ['å', 'a'],
+  ['ė', 'e'],
+  ['ę', 'e'],
+  ['ȯ', 'o'],
+  ['ų', 'u'],
+  // consonants (irregular: the diacritic changes the base letter)
+  ['ć', 'č'],
+  ['đ', 'dž'],
+  // consonants (softness dropped in standard orthography)
+  ['ĺ', 'l'],
+  ['ľ', 'l'],
+  ['ń', 'n'],
+  ['ŕ', 'r'],
+  ['ť', 't'],
+  ['t́', 't'],
+  ['ď', 'd'],
+  ['d́', 'd'],
+  ['ś', 's'],
+  ['ź', 'z'],
+];
+
+// Standard Latin → standard Cyrillic (normative transliteration table).
+// Digraphs must be tried before single letters, hence the length sort below.
+const LATIN_TO_CYRILLIC = [
+  ['dž', 'дж'],
+  ['lj', 'љ'],
+  ['nj', 'њ'],
+  ['a', 'а'],
+  ['b', 'б'],
+  ['c', 'ц'],
+  ['č', 'ч'],
+  ['d', 'д'],
+  ['e', 'е'],
+  ['ě', 'є'],
+  ['f', 'ф'],
+  ['g', 'г'],
+  ['h', 'х'],
+  ['i', 'и'],
+  ['j', 'ј'],
+  ['k', 'к'],
+  ['l', 'л'],
+  ['m', 'м'],
+  ['n', 'н'],
+  ['o', 'о'],
+  ['p', 'п'],
+  ['r', 'р'],
+  ['s', 'с'],
+  ['š', 'ш'],
+  ['t', 'т'],
+  ['u', 'у'],
+  ['v', 'в'],
+  ['y', 'ы'],
+  ['z', 'з'],
+  ['ž', 'ж'],
+];
+
+function byLengthDesc(pairs) {
+  return [...pairs].sort((a, b) => b[0].length - a[0].length);
+}
+
+const ETYM_TO_LATIN_SORTED = byLengthDesc(ETYM_TO_LATIN);
+const LATIN_TO_CYRILLIC_SORTED = byLengthDesc(LATIN_TO_CYRILLIC);
+
+function isUpper(ch) {
+  return ch !== ch.toLowerCase() && ch === ch.toUpperCase();
+}
+
+function restoreCase(sourceSegment, target) {
+  if (isUpper(sourceSegment[0])) {
+    return target.charAt(0).toUpperCase() + target.slice(1);
+  }
+  return target;
+}
+
+// Apply an ordered, case-insensitive replacement map. Unmatched characters
+// (spaces, punctuation, letters absent from the map) pass through unchanged.
+function applyMap(input, sortedPairs) {
+  let out = '';
+  let i = 0;
+  while (i < input.length) {
+    let matched = false;
+    for (const [from, to] of sortedPairs) {
+      const segment = input.substr(i, from.length);
+      if (segment.toLowerCase() === from) {
+        out += restoreCase(segment, to);
+        i += from.length;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      out += input[i];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+export function etymToStandardLatin(text) {
+  return applyMap(text, ETYM_TO_LATIN_SORTED);
+}
+
+export function etymToStandardCyrillic(text) {
+  return applyMap(etymToStandardLatin(text), LATIN_TO_CYRILLIC_SORTED);
+}

--- a/src/remark-isv-directive.js
+++ b/src/remark-isv-directive.js
@@ -1,10 +1,14 @@
 import { visit } from 'unist-util-visit';
+import { etymToStandardLatin, etymToStandardCyrillic } from "./isv-etym.js";
 
 /**
  * Remark plugin for Interslavic text directives.
  *
  * Supported inline directives:
- *   :isv[text]              — Interslavic text (Latin script)
+ *   :isv[text]              — Interslavic text (input etymological script);
+ *                             rendered in the reader's chosen alphabet
+ *                             (etymological / standard Latin / standard Cyrillic)
+ *                             via the navbar switcher
  *   :latn[text]             — Explicitly Latin-script text
  *   :cyrl[text]             — Explicitly Cyrillic-script text
  *   :ipa[text]              — IPA transcription
@@ -54,6 +58,31 @@ export default function remarkIsvDirective() {
       if (node.type !== 'textDirective') return;
 
       const data = node.data || (node.data = {});
+
+      // Etymological directive → three pre-rendered spans, one per alphabet.
+      // The active one is chosen at read time by CSS keyed on the
+      // `data-isv-alphabet` attribute set on <html> by the navbar switcher.
+      if (node.name === "isv") {
+        const source = (node.children || [])
+          .map((child) => (typeof child.value === "string" ? child.value : ""))
+          .join("");
+
+        const variant = (className, lang, value) => ({
+          type: "element",
+          tagName: "span",
+          properties: { className: [className], lang },
+          children: [{ type: "text", value }],
+        });
+
+        data.hName = "span";
+        data.hProperties = { className: ["etym"] };
+        data.hChildren = [
+          variant("etym-etym", "isv-Latn", source),
+          variant("etym-latn", "isv-Latn", etymToStandardLatin(source)),
+          variant("etym-cyrl", "isv-Cyrl", etymToStandardCyrillic(source)),
+        ];
+        return;
+      }
 
       // Abbreviation directive → <abbr>
       if (node.name === 'abbr') {

--- a/src/theme/NavbarItem/ComponentTypes.js
+++ b/src/theme/NavbarItem/ComponentTypes.js
@@ -1,0 +1,9 @@
+import DefaultNavbarItemComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import AlphabetSwitcher from '@site/src/components/AlphabetSwitcher';
+
+// Register a custom navbar item type usable from docusaurus.config.ts as
+// { type: 'custom-alphabetSwitcher' }.
+export default {
+  ...DefaultNavbarItemComponentTypes,
+  'custom-alphabetSwitcher': AlphabetSwitcher,
+};


### PR DESCRIPTION
Most of the doc is currently written with a Latin-first mindset, with Cyrillic partially supported in specific circumstances. To maintain parity without doubling the amount of text required, an orthographic selector widget is the best choice. The offered implementation uses etymological alphabet as input and lets user select etymological/Latin/Cyrillic.

The selector currently lives in the top bar, which looks passable on desktops and mobile (more work can be done to make it pretty).

The etym->Latin and etym->Cyrl converters seem to be close enough: digraphs and capitals seem to be handled correctly. I've not tested extensively.

Not all uses of `:isv[text]` are currently appropriate for this selector switching, so they may be swapped out for `:lat[]` and `:cyr[]` - but this can be a page-by-page process, not necessary to include in the current PR.

In future: instead of implementing converters for each project, make a JS/TS library supporting every possible converter and declension/conjugation need, and simply import it.